### PR TITLE
サーバー情報をアイコンのみの表示に切り替えできる機能の修正

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -822,7 +822,7 @@ function emitUpdReaction(emoji: string, delta: number) {
 .instanceicon {
 	display: block !important;
 	padding-top: 33px;
-	margin-right: -25px;
+	width: 0;
 	height: 25px;
 	z-index: 10;
 	position: sticky !important;
@@ -973,7 +973,7 @@ function emitUpdReaction(emoji: string, delta: number) {
 	.instanceicon {
 		padding-top: 29px;
 		height: 21px;
-		margin-right: -21px;
+		width: 0;
 	}
 }
 
@@ -1025,7 +1025,7 @@ function emitUpdReaction(emoji: string, delta: number) {
 	.instanceicon {
 		padding-top: 27px;
 		height: 19px;
-		margin-right: -19px;
+		width: 0;
 		top: calc(14px + var(--stickyTop, 0px));
 	}
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
![image](https://github.com/user-attachments/assets/651275c5-732c-4dba-873e-df6987fd01ae)
この画像が示す黄緑の部分がクリックできない問題を解決しました

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
クリック可能な範囲が狭まっている問題があった

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
